### PR TITLE
Improve resume page styling

### DIFF
--- a/app/components/ScrollTopButton.tsx
+++ b/app/components/ScrollTopButton.tsx
@@ -1,0 +1,31 @@
+"use client";
+import { useEffect, useState } from "react";
+import { FaArrowUp } from "react-icons/fa";
+
+export default function ScrollTopButton() {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const onScroll = () => {
+      setVisible(window.scrollY > 300);
+    };
+    window.addEventListener("scroll", onScroll);
+    return () => window.removeEventListener("scroll", onScroll);
+  }, []);
+
+  const scrollToTop = () => {
+    window.scrollTo({ top: 0, behavior: "smooth" });
+  };
+
+  return (
+    <button
+      aria-label="Scroll to top"
+      onClick={scrollToTop}
+      className={`fixed bottom-6 right-6 p-3 bg-blue-600 text-white rounded-full shadow-lg transition-opacity duration-300 ${
+        visible ? "opacity-100" : "opacity-0 pointer-events-none"
+      }`}
+    >
+      <FaArrowUp />
+    </button>
+  );
+}

--- a/app/resume/page.tsx
+++ b/app/resume/page.tsx
@@ -1,18 +1,19 @@
 import Link from 'next/link';
+import ScrollTopButton from "../components/ScrollTopButton";
 
 export default function ResumePage() {
   return (
-    <div className="max-w-screen-lg mx-auto space-y-8 text-gray-200">
+    <div className="max-w-screen-lg mx-auto space-y-8 p-6 sm:p-8 md:p-10 bg-gray-50 text-gray-900 rounded-xl shadow-lg">
       {/* Header */}
-      <header className="flex flex-col md:flex-row md:justify-between md:items-center gap-2 border-b border-gray-700 pb-4">
+      <header className="flex flex-col md:flex-row md:justify-between md:items-center gap-2 border-b border-gray-300 pb-4">
         <div>
-          <h1 className="text-3xl font-bold">Soroush Osanloo</h1>
-          <p className="text-gray-400">Thornhill, ON</p>
+          <h1 className="text-4xl font-bold">Soroush Osanloo</h1>
+          <p className="text-gray-600">Thornhill, ON</p>
         </div>
         <div className="space-y-1 md:text-right">
-          <p>Phone: <a href="tel:+14375566361" className="hover:underline">+1 (437)556-6361</a></p>
-          <p>Email: <a href="mailto:soroush.osanlo@gmail.com" className="hover:underline">soroush.osanlo@gmail.com</a></p>
-          <p>
+          <p className="text-sm">Phone: <a href="tel:+14375566361" className="hover:underline">+1 (437)556-6361</a></p>
+          <p className="text-sm">Email: <a href="mailto:soroush.osanlo@gmail.com" className="hover:underline">soroush.osanlo@gmail.com</a></p>
+          <p className="text-sm">
             <a href="#" className="hover:underline mr-2">@LinkedIn</a>
             <a href="#" className="hover:underline">@GitHub</a>
           </p>
@@ -20,21 +21,21 @@ export default function ResumePage() {
       </header>
 
       {/* Professional Summary */}
-      <section>
-        <h2 className="text-2xl font-semibold mb-2">Professional Summary</h2>
-        <p>
+      <section className="bg-white p-6 rounded-lg shadow border border-gray-200 space-y-2">
+        <h2 className="text-3xl font-bold mb-4">Professional Summary</h2>
+        <p className="text-base leading-relaxed">
           Resourceful and adaptable software developer with strengths in full-stack development,
           problem-solving, and teamwork.
         </p>
       </section>
 
       {/* Experience */}
-      <section>
-        <h2 className="text-2xl font-semibold mb-2">Experience</h2>
+      <section className="bg-white p-6 rounded-lg shadow border border-gray-200 space-y-4">
+        <h2 className="text-3xl font-bold mb-4">Experience</h2>
         <div className="space-y-6">
           <div>
             <h3 className="text-xl font-semibold">SAT Tutor – Webtree Academy, Toronto, ON</h3>
-            <p className="text-sm text-gray-400">June 2023 – September 2023</p>
+            <p className="text-sm text-gray-500">June 2023 – September 2023</p>
             <ul className="list-disc list-inside ml-4 mt-2 space-y-1">
               <li>One-on-one SAT tutoring, score improved from 800 to 1300+</li>
               <li>Study plan: time management, anxiety reduction, critical reading</li>
@@ -43,7 +44,7 @@ export default function ResumePage() {
           </div>
           <div>
             <h3 className="text-xl font-semibold">Tutor – Webtree Academy, Toronto, ON</h3>
-            <p className="text-sm text-gray-400">Nov 2022 – June 2023</p>
+            <p className="text-sm text-gray-500">Nov 2022 – June 2023</p>
             <ul className="list-disc list-inside ml-4 mt-2 space-y-1">
               <li>Tutored 10+ students in Advanced Functions, Calculus, Biology, etc.</li>
               <li>Helped students get into UofT, TMU, George Brown</li>
@@ -54,11 +55,11 @@ export default function ResumePage() {
       </section>
 
       {/* Education */}
-      <section>
-        <h2 className="text-2xl font-semibold mb-2">Education</h2>
+      <section className="bg-white p-6 rounded-lg shadow border border-gray-200 space-y-2">
+        <h2 className="text-3xl font-bold mb-4">Education</h2>
         <div>
           <h3 className="text-xl font-semibold">Seneca Polytechnic – Computer Programming Diploma</h3>
-          <p className="text-sm text-gray-400">Graduated Dec 2024 | GPA: 3.8</p>
+          <p className="text-sm text-gray-500">Graduated Dec 2024 | GPA: 3.8</p>
           <ul className="list-disc list-inside ml-4 mt-2 space-y-1">
             <li>Specialized in Java, SQL optimization, and system analysis</li>
             <li>Built REST APIs, practiced Agile, fixed client-server issues</li>
@@ -67,14 +68,14 @@ export default function ResumePage() {
       </section>
 
       {/* Technical Skills */}
-      <section>
-        <h2 className="text-2xl font-semibold mb-2">Technical Skills</h2>
+      <section className="bg-white p-6 rounded-lg shadow border border-gray-200 space-y-4">
+        <h2 className="text-3xl font-bold mb-4">Technical Skills</h2>
         <div className="space-y-4">
           <div>
             <h3 className="font-semibold">Languages/Frameworks</h3>
             <div className="flex flex-wrap gap-2 mt-1">
               {['C','C++','Java','Python','JS','C#','Node.js','.NET Core','Bash'].map((s) => (
-                <span key={s} className="bg-gray-800 px-3 py-1 rounded-full hover:bg-gray-700 transition text-sm">{s}</span>
+                <span key={s} className="bg-gray-100 text-gray-800 px-3 py-1 rounded-full shadow-sm text-sm">{s}</span>
               ))}
             </div>
           </div>
@@ -82,7 +83,7 @@ export default function ResumePage() {
             <h3 className="font-semibold">Web</h3>
             <div className="flex flex-wrap gap-2 mt-1">
               {['HTML','CSS','DOM','REST APIs','AJAX','JSON'].map((s) => (
-                <span key={s} className="bg-gray-800 px-3 py-1 rounded-full hover:bg-gray-700 transition text-sm">{s}</span>
+                <span key={s} className="bg-gray-100 text-gray-800 px-3 py-1 rounded-full shadow-sm text-sm">{s}</span>
               ))}
             </div>
           </div>
@@ -90,7 +91,7 @@ export default function ResumePage() {
             <h3 className="font-semibold">DB</h3>
             <div className="flex flex-wrap gap-2 mt-1">
               {['SQL Server','Oracle','MySQL','MongoDB','Stored Procs'].map((s) => (
-                <span key={s} className="bg-gray-800 px-3 py-1 rounded-full hover:bg-gray-700 transition text-sm">{s}</span>
+                <span key={s} className="bg-gray-100 text-gray-800 px-3 py-1 rounded-full shadow-sm text-sm">{s}</span>
               ))}
             </div>
           </div>
@@ -98,7 +99,7 @@ export default function ResumePage() {
             <h3 className="font-semibold">Mobile</h3>
             <div className="flex flex-wrap gap-2 mt-1">
               {['Xamarin Forms','Ionic (Angular)'].map((s) => (
-                <span key={s} className="bg-gray-800 px-3 py-1 rounded-full hover:bg-gray-700 transition text-sm">{s}</span>
+                <span key={s} className="bg-gray-100 text-gray-800 px-3 py-1 rounded-full shadow-sm text-sm">{s}</span>
               ))}
             </div>
           </div>
@@ -106,7 +107,7 @@ export default function ResumePage() {
             <h3 className="font-semibold">Apps</h3>
             <div className="flex flex-wrap gap-2 mt-1">
               {['Swagger','Postman','MVC','Unit testing'].map((s) => (
-                <span key={s} className="bg-gray-800 px-3 py-1 rounded-full hover:bg-gray-700 transition text-sm">{s}</span>
+                <span key={s} className="bg-gray-100 text-gray-800 px-3 py-1 rounded-full shadow-sm text-sm">{s}</span>
               ))}
             </div>
           </div>
@@ -114,7 +115,7 @@ export default function ResumePage() {
             <h3 className="font-semibold">DevOps</h3>
             <div className="flex flex-wrap gap-2 mt-1">
               {['Git','GitHub','Actions','Jenkins','Docker','Shell'].map((s) => (
-                <span key={s} className="bg-gray-800 px-3 py-1 rounded-full hover:bg-gray-700 transition text-sm">{s}</span>
+                <span key={s} className="bg-gray-100 text-gray-800 px-3 py-1 rounded-full shadow-sm text-sm">{s}</span>
               ))}
             </div>
           </div>
@@ -122,7 +123,7 @@ export default function ResumePage() {
             <h3 className="font-semibold">OS</h3>
             <div className="flex flex-wrap gap-2 mt-1">
               {['Windows','Linux/Unix'].map((s) => (
-                <span key={s} className="bg-gray-800 px-3 py-1 rounded-full hover:bg-gray-700 transition text-sm">{s}</span>
+                <span key={s} className="bg-gray-100 text-gray-800 px-3 py-1 rounded-full shadow-sm text-sm">{s}</span>
               ))}
             </div>
           </div>
@@ -130,7 +131,7 @@ export default function ResumePage() {
             <h3 className="font-semibold">Tools</h3>
             <div className="flex flex-wrap gap-2 mt-1">
               {['Jira','Confluence','Teams','SharePoint','Zoom'].map((s) => (
-                <span key={s} className="bg-gray-800 px-3 py-1 rounded-full hover:bg-gray-700 transition text-sm">{s}</span>
+                <span key={s} className="bg-gray-100 text-gray-800 px-3 py-1 rounded-full shadow-sm text-sm">{s}</span>
               ))}
             </div>
           </div>
@@ -138,7 +139,7 @@ export default function ResumePage() {
             <h3 className="font-semibold">Project Mgmt</h3>
             <div className="flex flex-wrap gap-2 mt-1">
               {['PMI','Gantt','MS Project'].map((s) => (
-                <span key={s} className="bg-gray-800 px-3 py-1 rounded-full hover:bg-gray-700 transition text-sm">{s}</span>
+                <span key={s} className="bg-gray-100 text-gray-800 px-3 py-1 rounded-full shadow-sm text-sm">{s}</span>
               ))}
             </div>
           </div>
@@ -146,7 +147,7 @@ export default function ResumePage() {
             <h3 className="font-semibold">AI</h3>
             <div className="flex flex-wrap gap-2 mt-1">
               {['Prompt engineering','ethics','tools'].map((s) => (
-                <span key={s} className="bg-gray-800 px-3 py-1 rounded-full hover:bg-gray-700 transition text-sm">{s}</span>
+                <span key={s} className="bg-gray-100 text-gray-800 px-3 py-1 rounded-full shadow-sm text-sm">{s}</span>
               ))}
             </div>
           </div>
@@ -154,7 +155,7 @@ export default function ResumePage() {
             <h3 className="font-semibold">Communication</h3>
             <div className="flex flex-wrap gap-2 mt-1">
               {['Reports','flowcharts','inclusive writing'].map((s) => (
-                <span key={s} className="bg-gray-800 px-3 py-1 rounded-full hover:bg-gray-700 transition text-sm">{s}</span>
+                <span key={s} className="bg-gray-100 text-gray-800 px-3 py-1 rounded-full shadow-sm text-sm">{s}</span>
               ))}
             </div>
           </div>
@@ -162,9 +163,9 @@ export default function ResumePage() {
       </section>
 
       {/* Languages */}
-      <section>
-        <h2 className="text-2xl font-semibold mb-2">Languages</h2>
-        <ul className="grid grid-cols-1 sm:grid-cols-2 gap-1 list-disc list-inside ml-4">
+      <section className="bg-white p-6 rounded-lg shadow border border-gray-200 space-y-2">
+        <h2 className="text-3xl font-bold mb-4">Languages</h2>
+        <ul className="grid grid-cols-1 sm:grid-cols-2 gap-y-1 gap-x-6 list-disc list-inside ml-4">
           <li>English: Native</li>
           <li>French: Beginner</li>
           <li>Persian: Native</li>
@@ -174,8 +175,8 @@ export default function ResumePage() {
       </section>
 
       {/* Project Highlights */}
-      <section>
-        <h2 className="text-2xl font-semibold mb-2">Project Highlights</h2>
+      <section className="bg-white p-6 rounded-lg shadow border border-gray-200 space-y-4">
+        <h2 className="text-3xl font-bold mb-4">Project Highlights</h2>
         <div className="space-y-4">
           <div>
             <h3 className="text-xl font-semibold">Digital Check Processing (Capstone)</h3>
@@ -189,8 +190,8 @@ export default function ResumePage() {
       </section>
 
       {/* Other Info */}
-      <section>
-        <h2 className="text-2xl font-semibold mb-2">Other Info</h2>
+      <section className="bg-white p-6 rounded-lg shadow border border-gray-200 space-y-2">
+        <h2 className="text-3xl font-bold mb-4">Other Info</h2>
         <ul className="list-disc list-inside ml-4 space-y-1">
           <li>International graduate on Canadian open work permit</li>
           <li>Recommendation letters available upon request</li>
@@ -201,11 +202,12 @@ export default function ResumePage() {
       <div className="pt-4">
         <Link
           href="/resume.pdf"
-          className="inline-block px-6 py-3 bg-blue-600 rounded-lg hover:bg-blue-700 transition"
+          className="inline-block px-6 py-3 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition"
         >
           Download PDF Resume
         </Link>
       </div>
+      <ScrollTopButton />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add floating scroll-to-top button
- update resume page layout to use a light background and card-style sections
- enlarge headings and improve font hierarchy
- add padding, shadows, and rounded corners for a modern look
- adjust language section spacing

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68410a652ccc83239baafcbcbbef92bb